### PR TITLE
Fixes a typo, UMD bundling and some package.json setup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "map-gl-utils",
   "version": "0.40.0",
   "description": "Utility functions for Mapbox GL JS or Maplibre GL JS",
-  "main": "dist/index.js",
+  "main": "umd/index.min.js",
   "module": "dist/index.esm.js",
   "type": "module",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ export default [
                 file: 'umd/index.min.js',
                 format: 'umd', // minified UMD version for browser
                 name: 'U',
-                plugins: [terser(), babel({ babelHelpers: 'bundled' })],
+                plugins: [terser()],
             },
         ],
         plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,10 +8,9 @@ export default [
         input: 'src/index.js',
         output: [
             {
-                file: 'umd/ndex.js',
+                file: 'umd/index.js',
                 format: 'umd', // UMD version for browser
                 name: 'U',
-                plugins: [],
             },
             {
                 file: 'umd/index.min.js',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,10 @@ export default [
             flow(),
             commonjs(),
             nodeResolve(),
-            babel({ babelHelpers: 'bundled' }),
+            babel({
+                babelHelpers: 'bundled',
+                presets: ['@babel/preset-env'],
+            }),
         ],
     },
 ];


### PR DESCRIPTION
This is just going of what I would think would be the right way to go about it. Very open to corrections.

We are experiencing some issues in Safari 10 with spread operators which prompted me to investigate and make the needed changes.