### PR TITLE
Hover popup mousemove

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ map.U.hoverFeatureState('mylayer', 'mysource', 'mysourcelayer',
 map.U.hoverPopup('mylayer', f => `<h3>${f.properties.Name}</h3> ${f.properties.Description}`, { anchor: 'left' });
 map.U.clickPopup('mylayer', f => `<h3>${f.properties.Name}</h3> ${f.properties.Description}`, { maxWidth: 500 });
 
+// Show the popup on 'mousemove' instead of 'mouseenter' so it changes when moving between immediately-adjacent
+// features in the same layer, or follows the pointer when hovering area features.
+map.U.hoverPopup('mylayer', f => `<h3>${f.properties.Name}</h3> ${f.properties.Description}`, {}, 'mousemove');
+
 // clickLayer() is like .on('click)', but can take an array and adds a 'features' member
 // to the event, for what got clicked on.
 map.U.clickLayer(['towns', 'town-labels'], e => panel.selectedId = e.features[0].id);

--- a/src/index.js
+++ b/src/index.js
@@ -376,12 +376,14 @@ class MapGlUtils implements UtilsFuncs {
     @param {string|Array<string>|RegExp|function} layers Layers to attach handler to.
     @param htmlFunc Function that receives feature and popup, returns HTML.
     @param {Object<PopupOptions>} popupOptions Options passed to `Popup()` to customise popup.
+    @param {string} showEvent mouse event to trigger the popup, defaults to "mouseenter"
     @example hoverPopup('mylayer', f => `<h3>${f.properties.Name}</h3> ${f.properties.Description}`, { anchor: 'left' });
     */
     hoverPopup(
         layers: LayerRef,
         htmlFunc: LayerCallback,
-        popupOptions?: PopupOptions = {}
+        popupOptions?: PopupOptions = {},
+        showEvent?: string = 'mouseenter'
     ): OffHandler {
         if (!this._mapgl) {
             throw 'Mapbox GL JS or MapLibre GL JS object required when initialising';
@@ -404,10 +406,10 @@ class MapGlUtils implements UtilsFuncs {
                 popup.remove();
             };
 
-            this.map.on('mouseenter', layer, mouseenter);
+            this.map.on(showEvent, layer, mouseenter);
             this.map.on('mouseout', layer, mouseout);
             return () => {
-                this.map.off('mouseenter', layer, mouseenter);
+                this.map.off(showEvent, layer, mouseenter);
                 this.map.off('mouseout', layer, mouseout);
                 mouseout();
             };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -979,6 +979,16 @@ describe('Hook functions return "remove" handlers', () => {
         expect(map.on).toHaveBeenCalledTimes(4);
         expect(map.off).toHaveBeenCalledTimes(4);
     });
+    test('hoverPopup on mousemove', () => {
+        map.U.addGeoJSON('source');
+        map.U.addLine('layer', 'source');
+        const remove = map.U.hoverPopup('layer', f => f.properties.name, {}, 'mousemove');
+        expect(map._handlers.mousemove).toBeDefined();
+        expect(map._handlers.mouseout).toBeDefined();
+        remove();
+        expect(map._handlers.mousemove).not.toBeDefined();
+        expect(map._handlers.mouseout).not.toBeDefined();
+    });
     test('clickPopup', () => {
         map.U.addGeoJSON('source');
         map.U.addLine('layer', 'source');


### PR DESCRIPTION
For your consideration, I needed to add in an additional argument to `hoverPopup` to allow me to change the mouse event for showing the popup to `mousemove`. When working with shapefiles that have overlapping area features or that otherwise don't have a gap between features, Mapbox only fires `mouseenter` when the mouse enters into an object of that layer, but not if the mouse moves from feature to feature in the same layer without ever leaving a feature completely. I wanted to be able to use your handy function, just have it trigger on `mousemove` instead in specific cases (the default works great for single-point features) to have the popup update content when moving between adjacent features without a gap.

It also can make for a nice user experience to have the tooltip following the mouse.

Using `mouseenter`, you can see it only updating when I move through an area where there are no features for that layer:

https://user-images.githubusercontent.com/2308923/171329556-1477c4ad-8df8-4743-bac2-f5de22d5bdb5.mp4

Setting the mode to `mousemove` instead:

https://user-images.githubusercontent.com/2308923/171329736-2c9ce8a7-b799-4bc6-8709-b1665a4406f4.mp4

Proposing dropping it at the end of the options list and defaulting it to `mouseenter` to maintain backwards-compatibility, but of course up to you if this is a welcome addition to your library.

I blind-wrote a test for it as well based on some of the other tests, but I couldn't get the tests to run using any combination of things I tried (Jest throws a `SyntaxError: Cannot use import statement outside a module` on the import statement in `noflow/index.test.js` even on a fresh download `yarn install && yarn pretest && yarn test` and other combinations of things on Node v17.8.0). Happy to revise if I'm running the tests wrong.
